### PR TITLE
Fixes build for windows with MSVC compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+*.log
+*.tlog

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,16 +17,27 @@ target_include_directories(dubins
     PUBLIC 
     include)
 
-target_link_libraries(dubins 
-    PUBLIC 
-    m)
-target_link_libraries(dubins PRIVATE --coverage)
+if (MSVC)
+    target_link_libraries(dubins 
+        PUBLIC )
+else()
+    target_link_libraries(dubins
+        PUBLIC
+        m)
+    target_link_libraries(dubins PRIVATE --coverage)
+endif(MSVC)
+# target_link_libraries(dubins PRIVATE --coverage)
 
 if (MSVC)
     target_compile_options(dubins PRIVATE /W3)
 else()
     target_compile_options(dubins PRIVATE -Wall -Wextra -Wpedantic -std=gnu89)
 endif()
+
+add_executable(demo
+    examples/demo.c)
+target_link_libraries(demo
+    dubins)
 
 enable_testing()
 

--- a/tests/stableapi_tests.cpp
+++ b/tests/stableapi_tests.cpp
@@ -1,6 +1,10 @@
 extern "C" {
 #include "dubins.h"
 }
+
+#ifdef WIN32
+#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
Hi Andrew! First, many thanks for your work , it works great! 👏

This pull request fixes compilation errors in the **unit tests** for `windows 10` and `Visual Studio 14 2015`.

To use the math library in MSVC, the `_USE_MATH_DEFINES`  should be defined. 
And also, there was an error in linking the math library, which is actually unnecessary for MSVC.

Additionally, i've included a compilation target for the `example`

Please let me know if you have problems or if this patch needs more work/refactor.